### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixedstr"
-version = "0.2.11"
+version = "0.3.0"
 authors = ["Chuck Liang"]
 edition = "2021"
 license = "MIT"
@@ -8,7 +8,12 @@ description = "strings of constant maximum size that can be copied and stack all
 repository = "https://github.com/chuckcscccl/fixedstr/"
 keywords = ["string"]
 
+
+[features]
+serde=["dep:serde"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 #static_assertions = "1.1.0"
+serde={version="1", optional=true}


### PR DESCRIPTION
Added support for fstr, zstr, and tstr being serialized and deserialized with serde.

It's behind an optional feature, so if you don't need it you don't need to have it in your binary