### PR TITLE
change the anti-feature "no-alloc" to the regular feature "alloc" 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["string","no-std"]
 
 
 [features]
-default = []
+default = ["alloc"]
 serde=["dep:serde"]
 std=[]
 fstr = ["std"]
@@ -20,7 +20,7 @@ shared-str=[]
 flex-str=[]
 circular-str=[]
 experimental=[]
-no-alloc=[]
+alloc=[]
 compressed-str=[]
 #prioritize-safety=[]
 

--- a/src/circular_string.rs
+++ b/src/circular_string.rs
@@ -9,9 +9,17 @@
 //! fixed strings with circular-queue backing
 
 use core::cmp::{min, Ordering, PartialOrd};
-#[cfg(not(feature = "no-alloc"))]
-extern crate alloc;
 use core::ops::Add;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(all(feature = "alloc",not(feature = "std")))]
+use alloc::string::String;
+
+#[cfg(feature = "std")]
+extern crate std;
+#[cfg(feature = "std")]
+use std::string::String;
 
 /// **This type is only available with the `circular-str` option.**
 /// A *circular string* is represented underneath by a fixed-size u8
@@ -604,10 +612,10 @@ impl<const N: usize> cstr<N> {
     }
 
     /// converts cstr to an owned string
-    #[cfg(not(feature = "no-alloc"))]
-    pub fn to_string(&self) -> alloc::string::String {
+    #[cfg(any(feature = "alloc", feature = "std"))]
+    pub fn to_string(&self) -> String {
         let (a, b) = self.to_strs();
-        let mut s = alloc::string::String::from(a);
+        let mut s = String::from(a);
         if b.len() > 0 {
             s.push_str(b);
         }

--- a/src/flexible_string.rs
+++ b/src/flexible_string.rs
@@ -9,9 +9,18 @@
 #![allow(unused_mut)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
-extern crate alloc;
 use crate::tstr;
 use crate::zstr;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(all(feature = "alloc",not(feature = "std")))]
+use alloc::string::String;
+
+#[cfg(feature = "std")]
+extern crate std;
+#[cfg(feature = "std")]
+use std::string::String;
 
 #[cfg(feature = "std")]
 use crate::fstr;
@@ -19,8 +28,6 @@ use crate::fstr;
 use crate::shared_structs::Strunion;
 use crate::shared_structs::Strunion::*;
 use crate::{str12, str128, str16, str192, str24, str256, str32, str4, str48, str64, str8, str96};
-use alloc::string::String;
-use alloc::vec::Vec;
 use core::cmp::{min, Ordering};
 use core::ops::Add;
 
@@ -130,8 +137,6 @@ impl<const N: usize> Flexstr<N> {
             fixed(s) => s.charlen(),
             owned(s) => {
                 s.chars().count()
-                //let v: Vec<_> = s.chars().collect();
-                //v.len()
             }
         } //match
     } //charlen

--- a/src/full_fixed.rs
+++ b/src/full_fixed.rs
@@ -7,13 +7,20 @@
 #![allow(unused_mut)]
 #![allow(dead_code)]
 
-#[cfg(feature = "std")]
-extern crate std;
 use crate::tiny_internal::*;
 use crate::zero_terminated::*;
 use core::cmp::{min, Ordering};
 use core::ops::Add;
 use std::eprintln;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(all(feature = "alloc",not(feature = "std")))]
+use alloc::string::String;
+
+#[cfg(feature = "std")]
+extern crate std;
+#[cfg(feature = "std")]
 use std::string::String;
 
 /// **This type is only available with the `std` (or `fstr`) feature.**

--- a/src/shared_string.rs
+++ b/src/shared_string.rs
@@ -6,12 +6,20 @@
 #![allow(unused_mut)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
-//extern crate std;
-//use std::string::String;
 use crate::shared_structs::Strunion;
 use crate::shared_structs::Strunion::*;
 use crate::tstr;
 use crate::zstr;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(all(feature = "alloc",not(feature = "std")))]
+use alloc::string::String;
+
+#[cfg(feature = "std")]
+extern crate std;
+#[cfg(feature = "std")]
+use std::string::String;
 
 #[cfg(feature = "std")]
 use crate::fstr;
@@ -22,9 +30,12 @@ use core::ops::Add;
 
 ////////////////////////////////////////////////////////////////////////
 ///////////// RC experiments
-extern crate alloc;
+#[cfg(all(feature = "alloc",not(feature = "std")))]
 use alloc::rc::Rc;
-use alloc::string::String;
+
+#[cfg(feature = "std")]
+use std::rc::Rc;
+
 use core::cell::RefCell;
 
 /// **This type is only available with the 'shared-str' option.**

--- a/src/shared_structs.rs
+++ b/src/shared_structs.rs
@@ -6,10 +6,18 @@
 #![allow(unused_mut)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
-extern crate alloc;
 use crate::tstr;
-use alloc::string::String;
 use Strunion::*;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(all(feature = "alloc",not(feature = "std")))]
+use alloc::string::String;
+
+#[cfg(feature = "std")]
+extern crate std;
+#[cfg(feature = "std")]
+use std::string::String;
 
 #[derive(Eq, PartialEq, Hash)]
 pub enum Strunion<const N: usize> {

--- a/src/tiny_internal.rs
+++ b/src/tiny_internal.rs
@@ -18,15 +18,17 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 
-#[cfg(not(feature = "no-alloc"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
+#[cfg(all(feature = "alloc",not(feature = "std")))]
+use alloc::string::String;
 
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 extern crate std;
+#[cfg(feature = "std")]
+use std::string::String;
 
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 use crate::fstr;
 
 use crate::zstr;
@@ -159,9 +161,9 @@ impl<const N: usize> tstr<N> {
     }
 
     /// converts tstr to an alloc::string::string
-    #[cfg(not(feature = "no-alloc"))]
-    pub fn to_string(&self) -> alloc::string::String {
-        alloc::string::String::from(self.to_str())
+    #[cfg(any(feature = "alloc", feature = "std"))]
+    pub fn to_string(&self) -> String {
+        String::from(self.to_str())
     }
 
     /// returns slice of u8 the array underneath the tstr
@@ -464,15 +466,14 @@ impl<T: AsMut<str> + ?Sized, const N: usize> core::convert::From<&mut T> for tst
     }
 }
 
-#[cfg(not(feature = "no-alloc"))]
-impl<const N: usize> core::convert::From<alloc::string::String> for tstr<N> {
-    fn from(s: alloc::string::String) -> tstr<N> {
+#[cfg(any(feature = "alloc",feature = "std"))]
+impl<const N: usize> core::convert::From<String> for tstr<N> {
+    fn from(s: String) -> tstr<N> {
         tstr::<N>::make(&s[..])
     }
 }
 
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 impl<const N: usize, const M: usize> std::convert::From<fstr<M>> for tstr<N> {
     fn from(s: fstr<M>) -> tstr<N> {
         tstr::<N>::make(s.to_str())
@@ -561,14 +562,12 @@ impl<const N: usize> Default for tstr<N> {
     }
 }
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 impl<const N: usize, const M: usize> PartialEq<tstr<N>> for fstr<M> {
     fn eq(&self, other: &tstr<N>) -> bool {
         other.to_str() == self.to_str()
     }
 }
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 impl<const N: usize, const M: usize> PartialEq<fstr<N>> for tstr<M> {
     fn eq(&self, other: &fstr<N>) -> bool {
         other.to_str() == self.to_str()

--- a/src/zero_terminated.rs
+++ b/src/zero_terminated.rs
@@ -19,20 +19,22 @@
 #![allow(unused_mut)]
 #![allow(dead_code)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(all(feature = "alloc",not(feature = "std")))]
+use alloc::string::String;
+
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
+extern crate std;
+#[cfg(feature = "std")]
+use std::string::String;
+
+#[cfg(feature = "std")]
 use crate::fstr;
 
 use crate::tstr;
 use core::cmp::{min, Ordering};
 use core::ops::Add;
-
-#[cfg(not(feature = "no-alloc"))]
-extern crate alloc;
-
-#[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
-extern crate std;
 
 /// `zstr<N>`: utf-8 strings of size up to N bytes. The strings are
 /// zero-terminated with a single byte, with the additional requirement that
@@ -203,9 +205,9 @@ impl<const N: usize> zstr<N> {
     } //blen, O(log N)
 
     /// converts zstr to an owned string
-    #[cfg(not(feature = "no-alloc"))]
-    pub fn to_string(&self) -> alloc::string::String {
-        alloc::string::String::from(self.to_str())
+    #[cfg(any(feature = "alloc", feature = "std"))]
+    pub fn to_string(&self) -> String {
+        String::from(self.to_str())
     }
 
     /// returns slice of u8 array underneath the zstr, **including the terminating 0**
@@ -604,14 +606,12 @@ impl<T: AsMut<str> + ?Sized, const N: usize> core::convert::From<&mut T> for zst
 }
 
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 impl<const N: usize> std::convert::From<std::string::String> for zstr<N> {
     fn from(s: std::string::String) -> zstr<N> {
         zstr::<N>::make(&s[..])
     }
 }
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 impl<const N: usize, const M: usize> std::convert::From<fstr<M>> for zstr<N> {
     fn from(s: fstr<M>) -> zstr<N> {
         zstr::<N>::make(s.to_str())
@@ -716,7 +716,6 @@ impl<const N: usize> Default for zstr<N> {
     }
 }
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 impl<const N: usize, const M: usize> PartialEq<zstr<N>> for fstr<M> {
     fn eq(&self, other: &zstr<N>) -> bool {
         other.to_str() == self.to_str()
@@ -724,7 +723,6 @@ impl<const N: usize, const M: usize> PartialEq<zstr<N>> for fstr<M> {
 }
 
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 impl<const N: usize, const M: usize> PartialEq<fstr<N>> for zstr<M> {
     fn eq(&self, other: &fstr<N>) -> bool {
         other.to_str() == self.to_str()
@@ -732,7 +730,6 @@ impl<const N: usize, const M: usize> PartialEq<fstr<N>> for zstr<M> {
 }
 
 #[cfg(feature = "std")]
-#[cfg(not(feature = "no-alloc"))]
 impl<const N: usize, const M: usize> PartialEq<&fstr<N>> for zstr<M> {
     fn eq(&self, other: &&fstr<N>) -> bool {
         other.to_str() == self.to_str()


### PR DESCRIPTION
as this is a general recommendation from https://doc.rust-lang.org/cargo/reference/features.html#feature-unification.
I did not yet change all the comments pointing to this feature. If you want me to continue, I would be happy to do so.

To keep the default behavior identical, I added "alloc" to the default features.